### PR TITLE
Fix Tab-Group Header not displayed 

### DIFF
--- a/packages/vue-components/src/Dropdown.vue
+++ b/packages/vue-components/src/Dropdown.vue
@@ -11,7 +11,7 @@
         :class="{'disabled': disabledBool}"
         data-bs-toggle="dropdown"
       >
-        <slot name="header"></slot>
+        <span v-html="tabgroupHeader"></span>
       </a>
     </slot>
     <slot name="dropdown-menu" :class="[{ 'show': show }, { 'dropdown-menu-end': menuAlignRight }]">
@@ -69,6 +69,10 @@ export default {
     type: {
       type: String,
       default: 'light',
+    },
+    tabgroupHeader: {
+      type: String,
+      default: '',
     },
     menuAlignRight: {
       type: Boolean,

--- a/packages/vue-components/src/Tabset.vue
+++ b/packages/vue-components/src/Tabset.vue
@@ -25,11 +25,9 @@
           :key="index"
           class="nav-item"
           :class="{active:t.active}"
+          :tabgroup-header="t.headerRendered"
           :disabled="t.disabled"
         >
-          <template #header>
-            <span v-html="t.headerRendered"></span>
-          </template>
           <li v-for="(tab, tabIndex) in t.tabs" :key="tabIndex">
             <a
               class="nav-link"

--- a/packages/vue-components/src/Tabset.vue
+++ b/packages/vue-components/src/Tabset.vue
@@ -28,6 +28,9 @@
           :class="{active:t.active}"
           :disabled="t.disabled"
         >
+          <template #header>
+            <span v-html="t.headerRendered"></span>
+          </template>
           <li v-for="(tab, tabIndex) in t.tabs" :key="tabIndex">
             <a
               class="nav-link"

--- a/packages/vue-components/src/Tabset.vue
+++ b/packages/vue-components/src/Tabset.vue
@@ -24,7 +24,6 @@
           v-else
           :key="index"
           class="nav-item"
-          :header="t.headerRendered"
           :class="{active:t.active}"
           :disabled="t.disabled"
         >


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [ ] Others, please explain:

~Fixes~ Refers to issue #/2524 

**Overview of changes:**

Header does not show up for the `TabGroup` component. This was likely due to the header being passed as a prop instead of a namedSlot into `Dropdown`. To fix this, pass header as named slot.

**Anything you'd like to highlight/discuss:**

From what I understand:
* `TabGroup` internally consists of the dropdown tab component. However, internally, TabGroup does not render this dropdown, but instead adds itself to the parent `TabSet`, which is then in charge of rendering children `Tab` or `TabGroup`. 
* In `TabSet`, the header was originally passed into Dropdown from Tabset as an attribute / vue prop of `Dropdown`. `Dropdown` then uses this prop to display the header:
  * [commit history](https://github.com/MarkBind/vue-strap/commit/96adcfb15cc90d7ccba796ab5771267eccfdef9a?diff=split&w=0)
* After that, to add markdown support to the header, the header was passed using slots. I would like to see if this is the source of the bug, but at this point, I can't seem to test this version of MarkBind, due to depreciated dependencies/errors faced.
  * [commit history](https://github.com/MarkBind/vue-strap/commit/04dd7e210f6cabea02c0e6e766869a1b1ea155ab) 

**[ Requesting Comments ]**: I don't quite understand how the Vue component's prop is being passed as a named slot. Refering to the [developer guide](https://markbind.org/devdocs/devGuide/development/writingComponents.html), I tried to trace the processing but I think I might be facing a skill issue. I'm confused as it says that "MarkBind attributes are passed to the Vue component as props. The type of the prop will be a String." However, the prop is able to be processed as a named slot.

This seems to be the core of the issue behind the bug. In `Tabset`, the header is being passed into `dropdown` similarly as a prop, which is not registered as a namedSlot, and ends up as an attribute when rendered. To fix this, I directly passed the header as a named slot. However the discrepancy and origin of the bug leaves me uneasy.



**Illustration**

Sample Code in MarkBind Syntax (where header is passed as an attribute):
```
<!-- header is being passed as a prop -->
<dropdown header="Prop Header" class="w-100"> 
    <ul slot="dropdown-menu" class="dropdown-menu">
      <li><a href="#dropdown" class="dropdown-item">Action</a></li>
      <li><a href="#dropdown" class="dropdown-item">Separated link</a></li>
    </ul>
  </dropdown>
```

Dropdown Vue Component Template (where header is accepted as a named slot):

https://github.com/MarkBind/markbind/blob/2c8276468592f964663ff3193e57345b63fa7f70/packages/vue-components/src/Dropdown.vue#L28-L51

Output:

![image](https://github.com/MarkBind/markbind/assets/111064611/6aa8868a-80d1-49bf-af99-f97b6f745b20)





Some references:
* [Legacy VueStrap Dropdown](https://github.com/yuche/vue-strap/blob/master/src/Dropdown.vue)
* [Add Embedded HTML in dropdown](https://github.com/MarkBind/vue-strap/commit/e9c4ec9b8966ba1ea7032b9294bb68651527e804)
* [Update of header slots for Vue Components](https://github.com/MarkBind/markbind/commit/640d18be106b5ca8b0b6ab0a60a21b3d19139b67)




**Testing instructions:**

<!--
  Any special testing instructions **not including** our automated tests.
-->

Refer to user guide: https://markbind.org/userGuide/components/presentation.html#tabs
Refer to localhost user guide: http://127.0.0.1:8080/userGuide/components/presentation.html#tabs


Before:
![image](https://github.com/gerteck/markbind/assets/111064611/2695a4ea-a77a-4835-a806-5e92f337e2a9)

After:
![image](https://github.com/gerteck/markbind/assets/111064611/8d0d4266-851e-466d-890d-4249c9160e4a)


**Proposed commit message: (wrap lines at 72 characters)**

<!--
  See this link for more info on how to write a good commit message:
  https://se-education.org/guides/conventions/git.html

  As best as possible, write a succinct commit title in 50 characters

|---------This is the width of 50 chars----------|
|-----------This is the width of 72 chars for your reference-----------|
-->

NA local PR

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [ ] Linked all related issues
- [ ] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->

---

**Reviewer checklist:**

Indicate the [SEMVER](https://semver.org/) impact of the PR:
- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [ ] Patch (when you make backward compatible bug fixes)

At the end of the review, please label the PR with the appropriate label: `r.Major`, `r.Minor`, `r.Patch`.

Breaking change release note preparation (if applicable):
- To be included in the release note for any feature that is made obsolete/breaking

> Give a brief explanation note about:
>   - what was the old feature that was made obsolete
>   - any replacement feature (if any), and
>   - how the author should modify his website to migrate from the old feature to the replacement feature (if possible).
